### PR TITLE
Optimización de consultas en rutas GET con lean y select para mejorar rendimiento

### DIFF
--- a/src/application/use-cases/get-task.use-case.ts
+++ b/src/application/use-cases/get-task.use-case.ts
@@ -1,15 +1,15 @@
 import { TaskRepository } from "../../domain/task.repository";
-import { Task } from "../../domain/task.entity";
+import { filteredTask } from "../../domain/task.entity";
 import { AppError } from "../../infrastructure/middlewares/errorHandler";
 
 export class GetTaskUseCase {
   constructor(private readonly taskRepository: TaskRepository) {}
 
-  public async execute(taskId: string): Promise<Task> {
+  public async execute(taskId: string): Promise<filteredTask> {
     if (!taskId) {
       throw new AppError("Task ID is required", 400);
     }
-    const task = await this.taskRepository.findById(taskId);
+    const task = await this.taskRepository.optimizedFindById(taskId);
     if (!task) {
       throw new AppError("Task not found", 404);
     }

--- a/src/domain/task.entity.ts
+++ b/src/domain/task.entity.ts
@@ -9,6 +9,13 @@ export interface TaskImage {
   path: string;
 }
 
+export interface filteredTask {
+  _id?: string;
+  status: TaskStatus;
+  price: number;
+  images: TaskImage[];
+}
+
 export class Task {
   _id?: string;
   status: TaskStatus;

--- a/src/domain/task.repository.ts
+++ b/src/domain/task.repository.ts
@@ -1,8 +1,9 @@
-import { Task } from "./task.entity";
+import { Task, filteredTask } from "./task.entity";
 
 export interface TaskRepository {
   save(task: Task): Promise<Task>;
   findById(taskId: string): Promise<Task | null>;
+  optimizedFindById(taskId: string): Promise<filteredTask | null>;
   updateTaskStatus(taskId: string, status: string): Promise<void>;
   completeTask(
     taskId: string,

--- a/tests/unit/application/getTask.spec.ts
+++ b/tests/unit/application/getTask.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GetTaskUseCase } from "../../../src/application/use-cases/get-task.use-case";
-import { Task } from "../../../src/domain/task.entity";
+import { filteredTask, TaskStatus } from "../../../src/domain/task.entity";
 import { TaskRepository } from "../../../src/domain/task.repository";
 
 describe("GetTaskUseCase", () => {
@@ -9,7 +9,7 @@ describe("GetTaskUseCase", () => {
 
   beforeEach(() => {
     taskRepository = {
-      findById: vi.fn(),
+      optimizedFindById: vi.fn(),
     } as unknown as TaskRepository;
 
     getTaskUseCase = new GetTaskUseCase(taskRepository);
@@ -17,28 +17,31 @@ describe("GetTaskUseCase", () => {
 
   it("should return a task when found", async () => {
     const taskId = "67c0452f0e6b87df0074d3f9";
-    const mockTask: Task = {
+    const mockTask: filteredTask = {
       _id: taskId,
-      originalPath: "https://example.com/image.jpg",
-      status: "pending",
+      status: TaskStatus.PENDING,
       price: 15.5,
+      images: [
+        { resolution: "hd", path: "path/to/image" },
+        { resolution: "sd", path: "path/to/image" },
+      ],
     };
 
-    (taskRepository.findById as vi.Mock).mockResolvedValue(mockTask);
+    (taskRepository.optimizedFindById as vi.Mock).mockResolvedValue(mockTask);
 
     const result = await getTaskUseCase.execute(taskId);
 
-    expect(taskRepository.findById).toHaveBeenCalledWith(taskId);
+    expect(taskRepository.optimizedFindById).toHaveBeenCalledWith(taskId);
     expect(result).toEqual(mockTask);
   });
 
   it("should throw an error when task is not found", async () => {
-    (taskRepository.findById as vi.Mock).mockResolvedValue(null);
+    (taskRepository.optimizedFindById as vi.Mock).mockResolvedValue(null);
 
     await expect(getTaskUseCase.execute("1234")).rejects.toThrow(
       "Task not found"
     );
 
-    expect(taskRepository.findById).toHaveBeenCalledWith("1234");
+    expect(taskRepository.optimizedFindById).toHaveBeenCalledWith("1234");
   });
 });

--- a/tests/unit/infra/task.routes.spec.ts
+++ b/tests/unit/infra/task.routes.spec.ts
@@ -16,7 +16,7 @@ const taskRepositoryMock = {
     price: 25,
     images: [],
   }),
-  findById: vi.fn().mockResolvedValue({
+  optimizedFindById: vi.fn().mockResolvedValue({
     _id: mockObjectId,
     originalPath: "https://example.com/image.jpg",
     status: "pending",

--- a/tests/unit/infra/taskWorker.spec.ts
+++ b/tests/unit/infra/taskWorker.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Worker } from "bullmq";
+import Redis from "ioredis";
+import { connectDB } from "../../../src/infrastructure/database/db";
+
+// Mock dependencies
+vi.mock("../../../src/infrastructure/database/db", () => ({
+  connectDB: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("bullmq");
+vi.mock("ioredis");
+vi.mock("../../src/infrastructure/database/db");
+vi.mock("../../src/helpers/processImage");
+vi.mock("../../src/infrastructure/repositories/task.repository.mongo");
+
+vi.stubEnv("REDIS_HOST", "localhost");
+vi.stubEnv("REDIS_PORT", "6380");
+vi.stubEnv("REDIS_DB", "0");
+
+describe("TaskWorker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("should initialize worker with correct configuration", async () => {
+    await import("../../../src/infrastructure/workers/taskWorker");
+
+    expect(Redis).toHaveBeenCalledWith({
+      host: "localhost",
+      port: 6380,
+      db: 0,
+      maxRetriesPerRequest: null,
+    });
+
+    expect(connectDB).toHaveBeenCalled();
+    expect(Worker).toHaveBeenCalledWith(
+      "imageProcessing",
+      expect.any(Function),
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
# Features Subidos

Este PR introduce mejoras en las consultas de la base de datos para los endpoints GET, optimizando el rendimiento mediante el uso de:

lean() para reducir la sobrecarga de Mongoose y mejorar tiempos de respuesta.
select() para obtener solo los campos necesarios, reduciendo la cantidad de datos transferidos.

# Cambios Principales:
✅ Se refactoriza findById en task.repository.mongo.ts para usar lean() y select().
✅ Se actualizan las pruebas unitarias (getTask.spec.ts) para reflejar estos cambios.
✅ Se verifica compatibilidad con los casos de uso actuales y se optimiza la respuesta del API.

## Beneficios esperados:
 Mejora en la velocidad de respuesta para consultas GET.
Reducción del uso de memoria en la aplicación.
Código más limpio y enfocado en recuperar solo los datos esenciales.